### PR TITLE
Fix/segfault ao module

### DIFF
--- a/src/bufferedao.c
+++ b/src/bufferedao.c
@@ -474,7 +474,7 @@ static PyMethodDef bufferedao_methods[] = {
     {"quit", (PyCFunction) bufferedao_quit, METH_NOARGS,
      "Stop buffered output thread"
     },
-    {NULL, NULL}  /* Sentinel */
+    {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 
 

--- a/src/bufferedao.c
+++ b/src/bufferedao.c
@@ -38,9 +38,9 @@
 
 // global state
 
-PyObject *error;  
-PyObject *log_debug; /* currently not used */
-PyObject *log_error;
+static PyObject *error = NULL;
+static PyObject *log_debug = NULL; /* currently not used */
+static PyObject *log_error = NULL;
 
 
 static PyObject *bufferedaoerror;

--- a/src/pcm/pcm.c
+++ b/src/pcm/pcm.c
@@ -262,8 +262,8 @@ static PyObject *py_rate_convert(PyObject *self, PyObject *args) {
   PyObject *py_last_l;
   PyObject *py_last_r;
 
-  int16_t last_l;
-  int16_t last_r;
+  int16_t last_l = 0;
+  int16_t last_r = 0;
 
   int firstsample;              /* are we dealing with the first sample */
 


### PR DESCRIPTION
The PR entails the following changes:
 * Initialization of two variables in `pcm.c` to avoid a compiler warning.
 * Full initialization of the sentinel in the array `bufferedao_methods` in `bufferedao.c` to avoid a compiler warning.
 * Declaration of three variables as static to fix a segmentation fault reported by @wimstefan in issue #4.